### PR TITLE
Fix types for TaskWithDetails and Vite server options

### DIFF
--- a/server/vite.ts
+++ b/server/vite.ts
@@ -23,7 +23,7 @@ export async function setupVite(app: Express, server: Server) {
   const serverOptions = {
     middlewareMode: true,
     hmr: { server },
-    allowedHosts: true,
+    allowedHosts: true as const,
   };
 
   const vite = await createViteServer({

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -279,9 +279,9 @@ export type InsertTimeEntry = z.infer<typeof insertTimeEntrySchema>;
 
 // Extended types for API responses
 export type TaskWithDetails = Task & {
-  project?: Project;
-  assignedUser?: User;
-  createdUser?: User;
+  project: Project | null;
+  assignedUser: User | null;
+  createdUser?: User | null;
   comments?: TaskComment[];
   files?: File[];
   timeEntries?: TimeEntry[];


### PR DESCRIPTION
## Summary
- update `TaskWithDetails` type to allow nullable relations
- adjust Vite server `allowedHosts` option

## Testing
- `npm run check` *(fails: multiple TypeScript errors remain)*

------
https://chatgpt.com/codex/tasks/task_e_68895dad174883228939eb3de352646b